### PR TITLE
Updated Gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,10 @@
 image:
   file: Dockerfile
+ports:
+- port: 6080
+  onOpen: notify
+- port: 5900
+  onOpen: ignore
 tasks:
 - command: >
     mkdir --parents build &&

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM gitpod/workspace-full
+FROM gitpod/workspace-full-vnc
 
 USER root
 # add your tools here
 RUN apt-get update && apt-get install -y \
-  netpbm
+  netpbm \
+  libsdl2-dev

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ make
 
 You can open the project in Gitpod, a free online dev evironment for GitHub:
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ssloy/tinyraycaster/tree/ea577d67088656918a85911448b9539421a8f3e1)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ssloy/tinyraycaster)
 
 
 On open, the editor will compile & run the program as well as open the resulting image in the editor's preview.


### PR DESCRIPTION
This PR adds VNC and SDL2 support to the gitpod config.

On start the user will be asked to open the VNC viewer on the right side or as an external browser window.

You can try it by opening this PR:

https://gitpod.io/#https://github.com/ssloy/tinyraycaster/pull/3