### PR TITLE
Fixing building on macOS. Backward compatible with Linux

### DIFF
--- a/gui.cpp
+++ b/gui.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <chrono>
 #include <thread>
+#include <cmath>
 #include "SDL.h"
 
 #include "utils.h"


### PR DESCRIPTION
(Tested on macOS 10.14.3 and Ubuntu 18.04)

To address: Issue https://github.com/ssloy/tinyraycaster/issues/1