### PR TITLE
Add extra argument.

### DIFF
--- a/utils.cpp
+++ b/utils.cpp
@@ -16,7 +16,7 @@ void unpack_color(const uint32_t &color, uint8_t &r, uint8_t &g, uint8_t &b, uin
 
 void drop_ppm_image(const std::string filename, const std::vector<uint32_t> &image, const size_t w, const size_t h) {
     assert(image.size() == w*h);
-    std::ofstream ofs(filename);
+    std::ofstream ofs(filename, std::ios::binary);
     ofs << "P6\n" << w << " " << h << "\n255\n";
     for (size_t i = 0; i < h*w; ++i) {
         uint8_t r, g, b, a;


### PR DESCRIPTION
Prevents opening the output file in text mode.