### PR TITLE
Make it compile on gcc 6.3.0 (size_t error)

### DIFF
--- a/framebuffer.h
+++ b/framebuffer.h
@@ -2,6 +2,7 @@
 #define FRAMEBUFFER_H
 
 #include <cstdint>
+#include <cstdlib>
 #include <vector>
 
 struct FrameBuffer {


### PR DESCRIPTION
Tiny fix, just to make it compile on gcc 6.3.0.
I got this error a couple times before the fix:

```
tinyraycaster/framebuffer.h:8:5: error: ‘size_t’ does not name a type
     size_t w, h; // image dimensions
```